### PR TITLE
fix: add pointer events none in hero

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -20,7 +20,7 @@ export default function Home() {
     <>
       <main className="text-white">
         <div className="relative h-screen">
-          <div className="absolute inset-0">
+          <div className="pointer-events-none absolute inset-0">
             <div className="flex h-screen w-full items-center justify-center">
               <div className="absolute">
                 <div className="relative -z-30 mx-auto w-[400px] max-w-[90%] animate-gradient-svg from-mountain-primary to-mountain-secondary blur-[1px] md:w-[746px] md:blur-sm lg:w-[900px] xl:w-[1200px]">


### PR DESCRIPTION
Se agrega la clase `pointer-events-none` a un `div` en la zona del "Hero" que está `absolute` y bloquea el funcionamiento esperado del puntero sobre el texto.

Ver issue https://github.com/JSConfCL/2024/issues/11