### PR TITLE
geekha/feat button add event to calendar

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, Star } from "lucide-react";
+import { ChevronDown, Star, Calendar } from "lucide-react";
 
 import { EventInfo } from "@/sections/EventInfo/EventInfo";
 import { Card } from "@/components/Card";
@@ -10,6 +10,7 @@ import { Particles } from "@/components/Particles";
 import { data, footer } from "@/lib/data";
 import { getMetaData, getViewports } from "@/lib/metadata";
 import { cn } from "@/lib/utils";
+import { ButtonSaveInCalendar } from "@/components/ButtonSaveInCalendar";
 
 export const generateMetadata = getMetaData;
 
@@ -47,7 +48,7 @@ export default function Home() {
                 Buscamos sponsors para talento, exposición de marca o
                 lanzamientos innovadores. ¿Listo para destacar? ¡Háznoslo saber!
               </div>
-              <div className="mx-auto inline-block">
+              <div className="mx-auto flex items-center gap-4 lg:min-w-[450px]">
                 <Link
                   href="https://tally.so/r/mO5j9A"
                   target="_blank"
@@ -55,6 +56,9 @@ export default function Home() {
                 >
                   Ser Sponsor <Star size={16} />
                 </Link>
+                <ButtonSaveInCalendar>
+                  Agendar evento <Calendar size={16} />
+                </ButtonSaveInCalendar>
               </div>
               <a
                 href="#more-info"

--- a/src/components/ButtonSaveInCalendar.tsx
+++ b/src/components/ButtonSaveInCalendar.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import React from "react";
+
+import { generateGoogleCalendarUrl } from "@/lib/calendar";
+import { JSCONF } from "@/lib/data";
+
+interface ButtonSaveInCalendarProps {
+  children: string | React.ReactNode;
+}
+
+export const ButtonSaveInCalendar = ({ children, ...props }: ButtonSaveInCalendarProps) => {
+  function handleSaveInCalendar() {
+    window.open(generateGoogleCalendarUrl({
+      dateStart: JSCONF.startDate,
+      // se suma un día para que el evento dure 3 días
+      // esto tengo que arreglarlo para que no queda tan hardcodeado
+      dateEnd: new Date(JSCONF.endDate.getTime() + 24 * 60 * 60 * 1000),
+      title: "JSConf Chile 2024",
+      description: "JSConf Chile te invita a un mundo donde JavaScript da forma al futuro. Este evento es un crisol de ideas innovadoras, charlas de expertos y una comunidad apasionada por la tecnología. Experimenta la combinación de tecnologías avanzadas de JavaScript, conecta con líderes de la industria y sé parte de un movimiento que impulsa la tecnología hacia adelante.",
+      location: JSCONF.place
+    }), '_blank');
+  }
+
+  return (
+    <button
+      {...props}
+      onClick={() => handleSaveInCalendar()}
+      className={`
+        relative
+        mb-2
+        flex
+        w-full
+        items-center
+        justify-center
+        gap-3
+        rounded-md
+
+        border-2
+        
+        border-gray-400
+        bg-transparent
+
+        px-8
+        py-4
+
+        text-sm
+        font-medium
+        text-gray-400
+        transition-all
+        duration-300
+
+        ease-in-out
+        hover:border-jsconf-red
+        hover:text-jsconf-red
+    `}
+    >
+      {children}
+    </button>
+  );
+};

--- a/src/lib/calendar.ts
+++ b/src/lib/calendar.ts
@@ -1,0 +1,23 @@
+import { dateToGoogleCalendarFormat } from './date';
+
+interface OptionalEventProperties {
+  dateStart: Date;
+  dateEnd: Date;
+  title: string;
+  description?: string;
+  location?: string;
+}
+
+export function generateGoogleCalendarUrl({dateStart, dateEnd, title, description, location}: OptionalEventProperties
+  ) {
+  const encodedUrl = encodeURI([
+    'https://www.google.com/calendar/render',
+    '?action=TEMPLATE',
+    `&text=${title}`,
+    `&dates=${dateToGoogleCalendarFormat(dateStart)}/${dateToGoogleCalendarFormat(dateEnd)}`,
+    `&details=${description}`,
+    `&location=${location}`,
+    '&sprop=&sprop=name:'].join(''));
+
+  return encodedUrl;
+}

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -23,3 +23,11 @@ export const formatDate = (date: Date | null): string | null => {
 
   return `${months[monthIndex]} ${day.toString().padStart(2, "0")} ${year}`;
 };
+
+export const dateToGoogleCalendarFormat = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = (date.getMonth() + 1).toString().padStart(2, '0');
+  const day = date.getDate().toString().padStart(2, '0');
+  
+  return [year,month,day].join('');
+}


### PR DESCRIPTION
Se propone agregar un botón para que los usuarios de la página web puedan guardar el evento en su calendario lo que resulta bastante útil para que las personas se acuerden del evento.

Propuesta del botón:
<img width="1657" alt="Screenshot 2024-03-28 at 1 47 05 PM" src="https://github.com/JSConfCL/2024/assets/499907/32bd9d5a-9554-4abc-ba9f-4a87b8bb233a">

Cómo se ve el evento al intentar crearse:
<img width="1657" alt="Screenshot 2024-03-28 at 1 47 12 PM" src="https://github.com/JSConfCL/2024/assets/499907/484380b4-77d7-4b31-917e-e4c6f0335ccb">

> Nota: por ahora solo está con Google Calendar, pero entiendo que se pueden agregar otros calendarios. Igual casi todo el mundo tiene cuenta de Google.